### PR TITLE
Coalescing Dedupe

### DIFF
--- a/jenkins-plugin-host/host/src/main/java/io/github/garrettswininger/plugin-host/HostedPluginFileSystemWatcher.java
+++ b/jenkins-plugin-host/host/src/main/java/io/github/garrettswininger/plugin-host/HostedPluginFileSystemWatcher.java
@@ -9,6 +9,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.DelayQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.logging.Logger;
@@ -26,6 +31,12 @@ public final class HostedPluginFileSystemWatcher implements RootAction {
     );
 
     private final static AutoloadRegistry registry = new AutoloadRegistry();
+
+    private final static ConcurrentHashMap<Path, AutoloadEvent> operationsMap
+        = new ConcurrentHashMap<>();
+
+    private final static DelayQueue<AutoloadEvent> operationsQueue
+        = new DelayQueue<>();
 
     private File getDataDirectory() {
         return new File(Jenkins.get().getRootDir(), "hosted-plugins");
@@ -68,16 +79,96 @@ public final class HostedPluginFileSystemWatcher implements RootAction {
     public String getUrlName() { return null; }
 
     public void onStart() {
-        final var dataDir = getDataDirectory();
-        final var autoloadDir = getAutoloadDirectory();
-        final var requiredDirs = List.of(dataDir, autoloadDir);
+        final var requiredDirs = List.of(
+            getDataDirectory(),
+            getAutoloadDirectory()
+        );
 
         requiredDirs.forEach(dir -> createDirectoryIfNotExists(dir));
         LOGGER.info("All required directories are present or have been created.");
 
-        final var fs = FileSystems.getDefault();
+        final var dirWatcherDaemon = new Thread(
+            new AutoloadDirectoryWatcher(),
+            "Jenkins-Plugin-Host-FS-Watcher"
+        );
 
-        final var dirWatcherDaemon = new Thread(() -> {
+        dirWatcherDaemon.setDaemon(true);
+        dirWatcherDaemon.start();
+
+        final var entryHandler = new Thread(
+            new AutoloadEventHandler(),
+            "Jenkins-Plugin-Host-Event-Handler"
+        );
+
+        entryHandler.setDaemon(true);
+        entryHandler.start();
+    }
+
+    private enum AutoloadEventAction {
+        REGISTER,
+        DEREGISTER,
+        RELOAD
+    }
+
+    private record AutoloadEvent(
+                AutoloadEventAction action, LocalDateTime expiry, Path path
+            ) implements Delayed {
+        @Override
+        public int compareTo(Delayed event) {
+            return Long.valueOf(this.getDelay(TimeUnit.NANOSECONDS))
+                .compareTo(event.getDelay(TimeUnit.NANOSECONDS));
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            /**
+             * NOTE(garrett): The DelayQueue<?> contract enforces that this is
+             * only called with TimeUnit.NANOSECONDS so we don't have to handle
+             * other values.
+             */
+            return ChronoUnit.NANOS.between(
+                LocalDateTime.now(),
+                this.expiry
+            );
+        }
+    }
+
+    private class AutoloadEventHandler implements Runnable {
+        @Override
+        public void run() {
+            while (true) {
+                try {
+                    final var event = operationsQueue.take();
+                    final var action = event.action();
+
+                    // TODO(garrett): Actually do useful things
+                    switch (action) {
+                        default:
+                            LOGGER.info(
+                                String.format(
+                                    "OBTAINED ACTION: %s (%s)\n",
+                                    event.path().toString(),
+                                    action.toString()
+                                )
+                            );
+
+                            break;
+                    }
+                } catch (InterruptedException ex) {
+                    LOGGER.severe(
+                        "Event handler thread interrupt, hosted plugins now frozen."
+                    );
+                }
+            }
+        }
+    }
+
+    private class AutoloadDirectoryWatcher implements Runnable {
+        @Override
+        public void run() {
+            final var autoloadDir = getAutoloadDirectory();
+            final var fs = FileSystems.getDefault();
+
             try (final var watcher = fs.newWatchService()) {
                 autoloadDir.toPath().register(
                     watcher,
@@ -96,12 +187,17 @@ public final class HostedPluginFileSystemWatcher implements RootAction {
                             continue;
                         }
 
-                        // NOTE(garrett): We'll want to actually re-order the
-                        // events here to handle deletions first. In the event
-                        // of a rename, we get a creation and deletion but these
-                        // may not be ordered from the underlying watch system
                         for (final var event: key.pollEvents()) {
                             final var kind = event.kind();
+
+                            if (kind == OVERFLOW) {
+                                LOGGER.warning(
+                                    "Overflow - Some events not delivered"
+                                );
+
+                                continue;
+                            }
+
                             final var path = autoloadDir.toPath().resolve(
                                 (Path)event.context()
                             );
@@ -112,22 +208,43 @@ public final class HostedPluginFileSystemWatcher implements RootAction {
 
                             final var isApplicable = hasExtension && !isDirectory;
 
-                            if ((kind == ENTRY_CREATE || kind == ENTRY_MODIFY)
-                                    && !isApplicable) {
+                            if (!isApplicable) {
                                 continue;
                             }
 
-                            if (kind == ENTRY_CREATE) {
-                                registry.register(path);
-                            } else if (kind == ENTRY_DELETE) {
-                                registry.deregister(path);
-                            } else if (kind == ENTRY_MODIFY) {
-                                registry.reload(path);
-                            } else if (kind == OVERFLOW) {
-                                LOGGER.info(
-                                    "Overflow - Some events not delivered"
+                            final AutoloadEventAction action =
+                                (kind == ENTRY_CREATE) ? AutoloadEventAction.REGISTER :
+                                (kind == ENTRY_DELETE) ? AutoloadEventAction.DEREGISTER :
+                                (kind == ENTRY_MODIFY) ? AutoloadEventAction.RELOAD :
+                                null;
+
+                            if (action == null) {
+                                throw new IllegalStateException(
+                                    String.format(
+                                        "Encountered an unexpected event type: %s",
+                                        kind.toString()
+                                    )
                                 );
                             }
+
+                            operationsMap.compute(path, ((pathKey, mappedEvent) -> {
+                                // FIXME(garrett): Actually compute
+                                if (mappedEvent != null) {
+                                    LOGGER.info("PRESENT!");
+                                    return mappedEvent;
+                                } else {
+                                    LOGGER.info("MISSING!");
+
+                                    final var newEvent = new AutoloadEvent(
+                                        action,
+                                        LocalDateTime.now().plusSeconds(30),
+                                        path
+                                    );
+
+                                    operationsQueue.put(newEvent);
+                                    return newEvent;
+                                }
+                            }));
                         }
 
                         key.reset();
@@ -145,9 +262,6 @@ public final class HostedPluginFileSystemWatcher implements RootAction {
                     )
                 );
             }
-        }, "Jenkins-Plugin-Host-FS-Watcher");
-
-        dirWatcherDaemon.setDaemon(true);
-        dirWatcherDaemon.start();
+        }
     }
 }


### PR DESCRIPTION
Properly handles file events for most common cases where modifications may appear after initial creation, depending on how the WatchService returns event kinds from the OS. Additionally, enables the cancellation of registrations when immediately deleted before the action has been triggered.